### PR TITLE
Added support for replacements in stringify (fixes #15)

### DIFF
--- a/src/StaticStringy.php
+++ b/src/StaticStringy.php
@@ -76,7 +76,7 @@ namespace Stringy;
  * @method static Stringy safeTruncate(string $stringInput, int $length, string $substring = '', string $encoding = null)
  * @method static Stringy shuffle(string $stringInput, string $encoding = null)
  * @method static Stringy shortenAfterWord(string $stringInput, int $length, string $strAddOn)
- * @method static Stringy slugify(string $stringInput, string $replacement = '-', string $language = 'de', boolean $strToLower = true)
+ * @method static Stringy slugify(string $stringInput, string $separator = '-', array $replacements = [], string $language = 'en')
  * @method static Stringy stripeCssMediaQueries(string $stringInput)
  * @method static Stringy stripeEmptyHtmlTags(string $stringInput)
  * @method static Stringy utf8ify(string $stringInput)


### PR DESCRIPTION
To answer #15, I added a `$replacements` array to the `slugify` method. Is offers more flexibility on what is changed. 

**I didn't test it, so please review the code and add test cases first before merging. Thanks!**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/stringy/18)
<!-- Reviewable:end -->
